### PR TITLE
[CIR-2233] Major bootstrap and play-frontend-hmrc bumps

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,7 @@
-@import "lib/govuk-frontend/govuk/base";
+$govuk-assets-path: "/phone-number-example-frontend/assets/lib/govuk-frontend/dist/govuk/assets/";
+$hmrc-assets-path: "/phone-number-example-frontend/assets/lib/hmrc-frontend/hmrc/";
+
+$govuk-include-default-font-face: false;
+
+@import "lib/govuk-frontend/dist/govuk/index";
+@import "lib/hmrc-frontend/hmrc/all";

--- a/app/uk/gov/hmrc/cipphonenumberfrontend/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/cipphonenumberfrontend/config/ErrorHandler.scala
@@ -17,24 +17,25 @@
 package uk.gov.hmrc.cipphonenumberfrontend.config
 
 import play.api.i18n.MessagesApi
-import play.api.mvc.Request
+import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import uk.gov.hmrc.cipphonenumberfrontend.views.html.ErrorTemplate
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
 
 import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ErrorHandler @Inject() (
     errorTemplate: ErrorTemplate,
     val messagesApi: MessagesApi
-) extends FrontendErrorHandler {
+)(implicit val ec: ExecutionContext)
+    extends FrontendErrorHandler {
 
   override def standardErrorTemplate(
       pageTitle: String,
       heading: String,
       message: String
-  )(implicit request: Request[_]): Html = {
-    errorTemplate(pageTitle, heading, message)
-  }
+  )(implicit request: RequestHeader): Future[Html] =
+    Future.successful(errorTemplate(pageTitle, heading, message))
 }

--- a/app/uk/gov/hmrc/cipphonenumberfrontend/controllers/SendCodeController.scala
+++ b/app/uk/gov/hmrc/cipphonenumberfrontend/controllers/SendCodeController.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.cipphonenumberfrontend.models.{
   VerificationResponse
 }
 import uk.gov.hmrc.cipphonenumberfrontend.views.html.SendCodePage
-import uk.gov.hmrc.http.HttpReads.{is2xx, is4xx}
+import uk.gov.hmrc.http.HttpErrorFunctions.{is2xx, is4xx}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
@@ -73,8 +73,9 @@ class SendCodeController @Inject() (
                   )
                 )
               } else {
-                SeeOther(
-                  s"/phone-number-example-frontend/verify-code?phoneNumber=${phoneNumber.phoneNumber}"
+                Redirect(
+                  routes.VerifyCodeController
+                    .verifyCodeForm(Some(phoneNumber.phoneNumber))
                 )
               }
 

--- a/app/uk/gov/hmrc/cipphonenumberfrontend/controllers/VerifyCodeController.scala
+++ b/app/uk/gov/hmrc/cipphonenumberfrontend/controllers/VerifyCodeController.scala
@@ -49,7 +49,7 @@ class VerifyCodeController @Inject() (
             )
           )
         case None =>
-          Future.successful(SeeOther("/phone-number-example-frontend"))
+          Future.successful(Redirect(routes.LandingPageController.landing()))
       }
     }
 
@@ -82,9 +82,9 @@ class VerifyCodeController @Inject() (
               if (optStatus.isDefined) {
                 optStatus.get.as[String] match {
                   case "CODE_VERIFIED" =>
-                    SeeOther("/phone-number-example-frontend?verified=true")
+                    Redirect(routes.LandingPageController.landing(Some(true)))
                   case _ =>
-                    Ok(
+                    BadRequest(
                       verifyPasscodePage(
                         PhoneNumberAndPasscode.form
                           .withError(
@@ -101,7 +101,7 @@ class VerifyCodeController @Inject() (
                     )
                 }
               } else {
-                Ok(
+                BadRequest(
                   verifyPasscodePage(
                     PhoneNumberAndPasscode.form
                       .withError(

--- a/app/uk/gov/hmrc/cipphonenumberfrontend/views/ErrorTemplate.scala.html
+++ b/app/uk/gov/hmrc/cipphonenumberfrontend/views/ErrorTemplate.scala.html
@@ -17,7 +17,9 @@
 @import uk.gov.hmrc.cipphonenumberfrontend.views.html.Layout
 
 @this(layout: Layout)
-@(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages)
+
+@(pageTitle: String, heading: String, message: String)(implicit request: RequestHeader, messages: Messages)
+
 @layout(pageTitle = Some(pageTitle)) {
     <h1 class="govuk-heading-xl">@{
         Text(heading).asHtml

--- a/app/uk/gov/hmrc/cipphonenumberfrontend/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/cipphonenumberfrontend/views/Layout.scala.html
@@ -16,24 +16,30 @@
 
 @import uk.gov.hmrc.cipphonenumberfrontend.config.AppConfig
 @import uk.gov.hmrc.cipphonenumberfrontend.views.html.FullWidthContent
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.hmrcstandardpage.{Banners, HmrcStandardPageParams, TemplateOverrides}
 
 @this(
         appConfig: AppConfig,
-        hmrcLayout: HmrcLayout,
+        hmrcLayout: HmrcStandardPage,
         fullWidthContent: FullWidthContent
 )
+
 @(
         pageTitle: Option[String] = None,
         backLinkUrl: Option[String] = None
-)(contentBlock: Html)(implicit request: Request[_], messages: Messages)
+)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
-@hmrcLayout(
+@hmrcLayout(HmrcStandardPageParams(
+    banners = Banners(
+        displayHmrcBanner = true
+    ),
+    templateOverrides = TemplateOverrides(
+        mainContentLayout = Some(fullWidthContent(_))
+    ),
     pageTitle = pageTitle,
     isWelshTranslationAvailable = appConfig.welshLanguageSupportEnabled,
-    backLinkUrl = backLinkUrl,
-    displayHmrcBanner = true,
-    mainContentLayout = Some(fullWidthContent(_))
-)(contentBlock)
+    backLink = backLinkUrl.map(url => BackLink.withDefaultText(href = url))
+))(contentBlock)
 
 @{
     //$COVERAGE-OFF$

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,6 @@ lazy val microservice = Project(appName, file("."))
   .settings(
     PlayKeys.playDefaultPort := 6080
   )
-  .settings(resolvers += Resolver.jcenterRepo)
 
 lazy val it = project
   .in(file("it"))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -30,6 +30,13 @@ play.http.errorHandler = "uk.gov.hmrc.cipphonenumberfrontend.config.ErrorHandler
 # ~~~~
 # Additional play modules can be added here
 
+# Session configuration
+# ~~~~~
+#TODO: 9.15.0 of Bootstrap sets all the below to `true`, but causes issues for us during Perf Testing with Gatling
+play.http.session.secure     = false
+play.http.flash.secure       = false
+play.i18n.langCookieSecure   = false
+
 microservice {
 
   services {

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -10,14 +10,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/connector.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
+            <pattern>[%highlight(%.-4level)][%replace(%logger){'.*\.(.*)','$1'}] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,6 +11,6 @@ object AppDependencies {
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-test-play-30"   % bootstrapPlayVersion,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30"  % "2.6.0"
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30"  % "2.7.0"
   ).map(_ % Test)
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,15 +1,16 @@
 import sbt.*
 
 object AppDependencies {
-  private val bootstrapPlayVersion = "8.6.0"
+
+  private val bootstrapPlayVersion = "9.18.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "8.5.0"
+    "uk.gov.hmrc" %% "play-frontend-hmrc-play-30" % "12.7.0"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapPlayVersion % Test,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30" % "2.6.0" % Test
-  )
+    "uk.gov.hmrc"       %% "bootstrap-test-play-30"   % bootstrapPlayVersion,
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-30"  % "2.6.0"
+  ).map(_ % Test)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,10 +8,10 @@ resolvers += Resolver.url(
 )(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.3")
+addSbtPlugin("uk.gov.hmrc"        % "sbt-auto-build"      % "3.24.0")
+addSbtPlugin("uk.gov.hmrc"        % "sbt-distributables"  % "2.6.0")
+addSbtPlugin("org.playframework"  % "sbt-plugin"          % "3.0.8")
 
-//addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"       % "2.3.1")
+addSbtPlugin("org.scalameta"      % "sbt-scalafmt"        % "2.5.5")
+addSbtPlugin("io.github.irundaia" % "sbt-sassify"         % "1.5.2")

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+sbt "run 6080 -Dplay.http.router=testOnlyDoNotUseInAppConf.Routes"

--- a/test/uk/gov/hmrc/cipphonenumberfrontend/config/ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberfrontend/config/ErrorHandlerSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.cipphonenumberfrontend.config
 
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -33,9 +34,9 @@ class ErrorHandlerSpec
 
   "standardErrorTemplate" should {
     "render HTML" in {
-      val html = handler.standardErrorTemplate("title", "heading", "message")(
-        fakeRequest
-      )
+      val html = handler
+        .standardErrorTemplate("title", "heading", "message")(fakeRequest)
+        .futureValue
       html.contentType shouldBe "text/html"
     }
   }

--- a/test/uk/gov/hmrc/cipphonenumberfrontend/controllers/VerifyCodeControllerSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberfrontend/controllers/VerifyCodeControllerSpec.scala
@@ -125,7 +125,7 @@ class VerifyCodeControllerSpec
         )
     }
 
-    "return OK when phone number fails verification" in new SetUp {
+    "return BAD_REQUEST when phone number fails verification" in new SetUp {
       val phoneNumber = "test"
       val passcode = "test"
       val request = fakeRequest.withFormUrlEncodedBody(
@@ -153,7 +153,7 @@ class VerifyCodeControllerSpec
           )
         )
       val result = controller.verifyCode(request)
-      status(result) shouldBe OK
+      status(result) shouldBe BAD_REQUEST
 
       verify(mockVerifyConnector, atLeastOnce())
         .verifyCode(meq(PhoneNumberAndPasscode(phoneNumber, passcode)))(
@@ -169,7 +169,7 @@ class VerifyCodeControllerSpec
         )(any(), any())
     }
 
-    "return OK when passcode has expired" in new SetUp {
+    "return BAD_REQUEST when passcode has expired" in new SetUp {
       val phoneNumber = "test"
       val passcode = "test"
       val request = fakeRequest.withFormUrlEncodedBody(
@@ -198,7 +198,7 @@ class VerifyCodeControllerSpec
           )
         )
       val result = controller.verifyCode(request)
-      status(result) shouldBe OK
+      status(result) shouldBe BAD_REQUEST
 
       verify(mockVerifyConnector, atLeastOnce())
         .verifyCode(meq(PhoneNumberAndPasscode(phoneNumber, passcode)))(


### PR DESCRIPTION
bootstrap: `8.6.0` -> `9.18.0`
play-frontend-hmrc: `8.5.0` -> `12.7.0`

----

- Update to use reverse routes instead of harc coded redirects
- Includes some other small refactoring as well as fixing the breaking changes from the major bumps

UT and IT pass 🟢 
Visually checked and run through locally 🟢 